### PR TITLE
feat/added config command

### DIFF
--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/deahtstroke/protheon/commands"
+	"github.com/spf13/cobra"
+)
+
+func Init() {
+	commands.RegisterCommand(newConfigCommand)
+}
+
+func newConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config COMMAND",
+		Short: "Manage saved Protheon ETL configs",
+		Long:  "Manage saved Protheon ETL configurations that are saved by the user",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	return cmd
+}

--- a/cmd/protheon.go
+++ b/cmd/protheon.go
@@ -10,6 +10,7 @@ import (
 	"github.com/deahtstroke/protheon/commands"
 	"github.com/spf13/cobra"
 
+	_ "github.com/deahtstroke/protheon/cmd/config"
 	_ "github.com/deahtstroke/protheon/cmd/run"
 )
 


### PR DESCRIPTION
Added a cobra command that manages run configurations, e.g., the YAML/TOML configs that are used to define ETL runs. This command will have several sub-commands such as `edit`, `list`, `delete`, basic CRUD operations. How a user saves a run is still to be defined.