### PR TITLE
feat: Added list configs command

### DIFF
--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -18,5 +18,6 @@ func newConfigCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCreateConfigCommand())
+	cmd.AddCommand(NewConfigListCommand())
 	return cmd
 }

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/deahtstroke/protheon/internal/config"
+	"github.com/deahtstroke/protheon/internal/db"
+	"github.com/spf13/cobra"
+)
+
+func NewConfigListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all ETL run configurations",
+		Long:    "Lists all created ETL run configurations created",
+		Aliases: []string{"ls", "ll"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runListConfigs()
+		},
+	}
+	return cmd
+}
+
+func runListConfigs() error {
+	dbPath := config.GlobalDbDir()
+	ctx := context.Background()
+
+	if err := ensureDir(dbPath); err != nil {
+		return err
+	}
+
+	if err := ensureDir(config.GlobalConfigDataDir()); err != nil {
+		return err
+	}
+
+	conn, err := db.Connect(fmt.Sprintf("file:%s/%s", dbPath, "protheon.db"))
+	if err != nil {
+		log.Fatalf("Unable to connect to sqlite DB: %v", err)
+	}
+	repo := db.NewRepository(conn)
+	cfgService := config.NewService(repo)
+
+	if err := cfgService.ListConfigs(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -8,12 +8,16 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/deahtstroke/protheon/internal/db"
 )
 
 type Service interface {
 	CreateConfig(context.Context, string, string) (*db.Config, error)
+	ListConfigs(context.Context) error
 }
 
 type ConfigService struct {
@@ -24,6 +28,27 @@ func NewService(repo *db.Repository) Service {
 	return &ConfigService{
 		Repository: repo,
 	}
+}
+
+func (s *ConfigService) ListConfigs(ctx context.Context) error {
+	configs, err := s.Repository.GetAllConfigs(ctx)
+	if err != nil {
+		return err
+	}
+
+	headers := []string{"CONFIG ID", "ALIAS", "CREATED AT"}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	defer w.Flush()
+
+	header := strings.Join(headers, "\t")
+	fmt.Fprintln(w, header)
+
+	for _, config := range configs {
+		t := time.Unix(config.CreatedAt, 0)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", config.Id, config.Alias, t.Format(time.RFC1123))
+	}
+
+	return nil
 }
 
 func (s *ConfigService) CreateConfig(ctx context.Context, format, alias string) (*db.Config, error) {

--- a/internal/db/config.sql.go
+++ b/internal/db/config.sql.go
@@ -55,3 +55,28 @@ func (r *Repository) ExistsByAlias(ctx context.Context, args ExistsByAliasParams
 
 	return exists, err
 }
+
+const getAllConfis = `
+ SELECT id, alias, created_at
+ FROM config c
+`
+
+func (r *Repository) GetAllConfigs(ctx context.Context) ([]Config, error) {
+	rows, err := r.db.QueryContext(ctx, getAllConfis)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var res []Config
+	for rows.Next() {
+		var config Config
+		if err := rows.Scan(&config.Id, &config.Alias, &config.CreatedAt); err != nil {
+			return nil, err
+		}
+		res = append(res, config)
+	}
+
+	return res, rows.Err()
+}


### PR DESCRIPTION
Added a `protheon config [list|ls|ll]` sub-command. Lists out the the config's `ID`, `alias` and `created time`. We can add a few other fields later.

closes #6 